### PR TITLE
Add chart themes including existing line and new dots and icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ Usage:
 Flags:
   -d, --days int          Stocks from X number of days ago.
   -h, --help              help for stonks
-  -i, --interval string   stonks -t X[m|h] (eg 15m, 5m, 1h, 1d) (default "15m")
+  -i, --interval string   stonks -i X[m|h] (eg 15m, 5m, 1h, 1d) (default "15m")
   -n, --name string       Optional name for a stonk save
   -r, --remove string     Remove an item from favourites
   -s, --save string       Add an item to the default stonks command. (Eg: -s AMD -n "Advanced Micro Devices")
+  -t, --theme string      Display theme for the chart (Options: "line", "dot", "icon") (default "line")
+  -v, --version           stonks version
   -w, --week              Display the last week (will set interval to 1d)
 ```
 


### PR DESCRIPTION
Adds some new chart theme styles:

<img width="709" alt="Screen Shot 2020-05-19 at 22 09 45" src="https://user-images.githubusercontent.com/24260/82343869-90113f80-9a1d-11ea-8972-4fbd6ff085e0.png">
