### PR TITLE
Add year and YTD display mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Flags:
   -s, --save string       Add an item to the default stonks command. (Eg: -s AMD -n "Advanced Micro Devices")
   -t, --theme string      Display theme for the chart (Options: "line", "dot", "icon") (default "line")
   -v, --version           stonks version
-  -w, --week              Display the last week (will set interval to 1d)
+  -w, --week              Display the last week (will set interval to 1d)              
+  -y, --year              Display the last year (will set interval to 1mo)
+      --ytd               Display the year to date (will set interval to 1mo)
 ```
 
 ### `$ stonks`

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Flags:
   -t, --theme string      Display theme for the chart (Options: "line", "dot", "icon") (default "line")
   -v, --version           stonks version
   -w, --week              Display the last week (will set interval to 1d)              
-  -y, --year              Display the last year (will set interval to 1mo)
-      --ytd               Display the year to date (will set interval to 1mo)
+  -y, --year              Display the last year (will set interval to 5d)
+      --ytd               Display the year to date (will set interval to 5d)
 ```
 
 ### `$ stonks`

--- a/main.go
+++ b/main.go
@@ -155,13 +155,13 @@ func main() {
 				var start *datetime.Datetime
 				var end *datetime.Datetime
 				if *year {
-					intervalCmd = datetime.OneMonth
+					intervalCmd = datetime.FiveDay
 					rn := time.Now()
 					e := rn.AddDate(-1, 0, 0)
 					start = datetime.New(&e)
 					end = datetime.New(&rn)
 				} else if *ytd {
-					intervalCmd = datetime.OneMonth
+					intervalCmd = datetime.FiveDay
 					rn := time.Now()
 					e := rn.AddDate(0, -int(rn.Month()), -rn.Day())
 					start = datetime.New(&e)
@@ -197,8 +197,8 @@ func main() {
 		},
 	}
 	interval = rootCmd.PersistentFlags().StringP("interval", "i", "15m", "stonks -i X[m|h] (eg 15m, 5m, 1h, 1d)")
-	year = rootCmd.PersistentFlags().BoolP("year", "y", false, "Display the last year (will set interval to 1mo)")
-	ytd = rootCmd.PersistentFlags().Bool("ytd", false, "Display the year to date (will set interval to 1mo)")
+	year = rootCmd.PersistentFlags().BoolP("year", "y", false, "Display the last year (will set interval to 5d)")
+	ytd = rootCmd.PersistentFlags().Bool("ytd", false, "Display the year to date (will set interval to 5d)")
 	week = rootCmd.PersistentFlags().BoolP("week", "w", false, "Display the last week (will set interval to 1d)")
 	days = rootCmd.PersistentFlags().IntP("days", "d", 0, "Stocks from X number of days ago.")
 	theme = rootCmd.PersistentFlags().StringP("theme", "t", "", "Display theme for the chart (Options: \"line\", \"dot\", \"icon\")")

--- a/main.go
+++ b/main.go
@@ -23,6 +23,8 @@ var (
 	save,
 	remove,
 	name *string
+	year	*bool
+	ytd		*bool
 	week    *bool
 	version *bool
 	theme   *string
@@ -152,7 +154,19 @@ func main() {
 				var intervalCmd datetime.Interval
 				var start *datetime.Datetime
 				var end *datetime.Datetime
-				if *week {
+				if *year {
+					intervalCmd = datetime.OneMonth
+					rn := time.Now()
+					e := rn.AddDate(-1, 0, 0)
+					start = datetime.New(&e)
+					end = datetime.New(&rn)
+				} else if *ytd {
+					intervalCmd = datetime.OneMonth
+					rn := time.Now()
+					e := rn.AddDate(0, -int(rn.Month()), -rn.Day())
+					start = datetime.New(&e)
+					end = datetime.New(&rn)
+				}else if *week {
 					intervalCmd = datetime.OneHour
 					rn := time.Now()
 					e := rn.AddDate(0, 0, -7)
@@ -183,6 +197,8 @@ func main() {
 		},
 	}
 	interval = rootCmd.PersistentFlags().StringP("interval", "i", "15m", "stonks -i X[m|h] (eg 15m, 5m, 1h, 1d)")
+	year = rootCmd.PersistentFlags().BoolP("year", "y", false, "Display the last year (will set interval to 1mo)")
+	ytd = rootCmd.PersistentFlags().Bool("ytd", false, "Display the year to date (will set interval to 1mo)")
 	week = rootCmd.PersistentFlags().BoolP("week", "w", false, "Display the last week (will set interval to 1d)")
 	days = rootCmd.PersistentFlags().IntP("days", "d", 0, "Stocks from X number of days ago.")
 	theme = rootCmd.PersistentFlags().StringP("theme", "t", "", "Display theme for the chart (Options: \"line\", \"dot\", \"icon\")")


### PR DESCRIPTION
Added year and YTD display mode:

- The `--year` or `-y` flag display the last year setting interval to five days.
- The `--ytd` (without shorthand letter) flag display the period since the first day of the current year, setting interval to five days.

Updated `README.md` with the new option flags.